### PR TITLE
Added ability to merge in json test results

### DIFF
--- a/coveralls/__init__.py
+++ b/coveralls/__init__.py
@@ -1,5 +1,5 @@
 __author__ = 'Andrea De Marco <24erre@gmail.com>'
-__version__ = '2.4.3'
+__version__ = '2.4.4'
 __classifiers__ = [
     'Development Status :: 5 - Production/Stable',
     'Intended Audience :: Developers',
@@ -51,11 +51,13 @@ def parse_args():
     parser.add_argument('--config_file', '-c', help='coverage config file name', default='.coveragerc')
     parser.add_argument('--coveralls_yaml', '-y', help='coveralls yaml file name', default='.coveralls.yml')
     parser.add_argument('--ignore-errors', '-i', help='gnore errors while reading source files', action='store_true', default=False)
+    parser.add_argument('--merge_file', '-m', help='json file containing coverage data to be merged (for merging javascript coverage)', default=None)
     args = parser.parse_args()
     args.base_dir = os.path.abspath(args.base_dir)
     args.data_file = os.path.join(args.base_dir, args.data_file)
     args.config_file = os.path.join(args.base_dir, args.config_file)
     args.coveralls_yaml = os.path.join(args.base_dir, args.coveralls_yaml)
+    args.merge_file = os.path.join(args.base_dir, args.merge_file) if args.merge_file else None
     yml = {}
     try:
         with open(args.coveralls_yaml, 'r') as fp:
@@ -85,7 +87,7 @@ def wear(args=None):
         service_job_id=args.service_job_id,
         service_name=args.service_name,
         git=gitrepo(args.base_dir),
-        source_files=coverage.coveralls(args.base_dir, ignore_errors=args.ignore_errors),
+        source_files=coverage.coveralls(args.base_dir, ignore_errors=args.ignore_errors, merge_file=args.merge_file),
     )
     logger.info(response.status_code)
     logger.info(response.text)

--- a/coveralls/control.py
+++ b/coveralls/control.py
@@ -3,7 +3,7 @@ from coveralls.report import CoverallsReporter
 
 
 class coveralls(coverage):
-    def coveralls(self, base_dir, ignore_errors=False):
+    def coveralls(self, base_dir, ignore_errors=False, merge_file=None):
         reporter = CoverallsReporter(self, self.config)
         reporter.find_code_units(None)
-        return reporter.report(base_dir, ignore_errors=ignore_errors)
+        return reporter.report(base_dir, ignore_errors=ignore_errors, merge_file=merge_file)

--- a/coveralls/report.py
+++ b/coveralls/report.py
@@ -1,9 +1,11 @@
+import json
+
 from coverage.report import Reporter
 from coverage.misc import NotPython
 
 
 class CoverallsReporter(Reporter):
-    def report(self, base_dir, ignore_errors=False):
+    def report(self, base_dir, ignore_errors=False, merge_file=None):
         ret = []
         for cu in self.code_units:
             try:
@@ -30,4 +32,13 @@ class CoverallsReporter(Reporter):
                 'source': ''.join(source).rstrip(),
                 'coverage': coverage_list,
             })
+
+        # if there's a merge file, load that and append it to the results as well
+        if merge_file:
+            with open(merge_file, 'r') as mfp:
+                data = json.loads(mfp.read())
+                source_files = data.get('source_files')
+                if source_files:
+                    ret.extend(source_files)
+
         return ret

--- a/coveralls/tests.py
+++ b/coveralls/tests.py
@@ -20,6 +20,7 @@ class Arguments(object):
     data_file = os.path.join(base_dir, '.coverage')
     config_file = os.path.join(base_dir, '.coveragerc')
     ignore_errors = False
+    merge_file = os.path.join(base_dir, 'merge.json')
 
 
 GIT_EXP = {
@@ -33,7 +34,7 @@ GIT_EXP = {
     },
     'remotes': [
         {
-            'url': 'https://github.com/z4r/python-coveralls-example.git',
+            'url': 'git@github.com:insurancezebra/python-coveralls-example.git',
             'name': 'origin'
         }
     ],
@@ -57,6 +58,14 @@ SOURCE_FILES = [
         'coverage': [1, None, 1, None, None, 1, 0, None, None, None, None, None]
     }
 
+]
+
+MERGE_SOURCE_FILES = [
+    {
+        'source': "var foo = 'bar';",
+        'name': "example/exjs.js",
+        'coverage': [1]
+    }
 ]
 
 
@@ -92,6 +101,11 @@ class CoverallsTestCase(TestCase):
         coverage = control.coveralls(data_file=Arguments.data_file, config_file=Arguments.config_file)
         coverage.load()
         self.assertEqual(coverage.coveralls(Arguments.base_dir), SOURCE_FILES)
+
+    def test_coveralls_with_merge(self):
+        coverage = control.coveralls(data_file=Arguments.data_file, config_file=Arguments.config_file)
+        coverage.load()
+        self.assertEqual(coverage.coveralls(Arguments.base_dir, merge_file=Arguments.merge_file), SOURCE_FILES + MERGE_SOURCE_FILES)
 
     @httprettified
     def test_api(self):


### PR DESCRIPTION
We needed the ability to merge Javascript tests results with the Python coverage results. The Javascript results are in lcov format and there is already a package called coveralls-lcov which can be used with the -v and -n switches to convert that to json. After that, it's a simple matter of appending the results. I've added a corresponding pull request in python-coveralls-example.
