### PR TITLE
Support latest coverage 40x

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ install:
   - pip install -U pip
   - python setup.py develop
 before_script:
-  - pip install -r test_requirements.txt --use-mirrors
+  - pip install -r test_requirements.txt
   - git clone https://github.com/z4r/python-coveralls-example.git
   - cd python-coveralls-example
   - git checkout -qf 3e82fd5159b84bebe9bc6c9fd3959f322e6f7098

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ install:
   - pip install -U pip
   - python setup.py develop
 before_script:
-  - pip install -U -r test_requirements.txt --use-mirrors
+  - pip install -r test_requirements.txt --use-mirrors
   - git clone https://github.com/z4r/python-coveralls-example.git
   - cd python-coveralls-example
   - git checkout -qf 3e82fd5159b84bebe9bc6c9fd3959f322e6f7098

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,8 @@ python:
   - "3.5-dev"
   - "nightly"
 install:
-  - pip install -e . --use-mirrors
+  - pip install -U pip
+  - python setup.py develop
 before_script:
   - pip install -U -r test_requirements.txt --use-mirrors
   - git clone https://github.com/z4r/python-coveralls-example.git

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,10 @@ python:
   - "2.6"
   - "2.7"
   - "3.3"
+  - "3.4"
+  - "3.5"
+  - "3.5-dev"
+  - "nightly"
 install:
   - pip install -e . --use-mirrors
 before_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,6 @@ python:
   - "3.4"
   - "3.5"
   - "3.5-dev"
-  - "nightly"
 install:
   - pip install -U pip
   - python setup.py develop

--- a/coveralls/control.py
+++ b/coveralls/control.py
@@ -1,9 +1,9 @@
-from coverage.control import coverage
+from coverage.control import Coverage
 from coveralls.report import CoverallsReporter
 
 
-class coveralls(coverage):
+class coveralls(Coverage):
     def coveralls(self, base_dir, ignore_errors=False, merge_file=None):
         reporter = CoverallsReporter(self, self.config)
-        reporter.find_code_units(None)
+        reporter.find_file_reporters(None)
         return reporter.report(base_dir, ignore_errors=ignore_errors, merge_file=merge_file)

--- a/coveralls/report.py
+++ b/coveralls/report.py
@@ -7,9 +7,9 @@ from coverage.misc import NotPython
 class CoverallsReporter(Reporter):
     def report(self, base_dir, ignore_errors=False, merge_file=None):
         ret = []
-        for cu in self.code_units:
+        for fr in self.file_reporters:
             try:
-                with open(cu.filename) as fp:
+                with open(fr.filename) as fp:
                     source = fp.readlines()
             except IOError:
                 if ignore_errors:
@@ -17,7 +17,7 @@ class CoverallsReporter(Reporter):
                 else:
                     raise
             try:
-                analysis = self.coverage._analyze(cu)
+                analysis = self.coverage._analyze(fr)
             except NotPython:
                 if ignore_errors:
                     continue
@@ -28,7 +28,7 @@ class CoverallsReporter(Reporter):
                 if lineno + 1 in analysis.statements:
                     coverage_list[lineno] = int(lineno + 1 not in analysis.missing)
             ret.append({
-                'name': cu.filename.replace(base_dir, '').lstrip('/'),
+                'name': fr.filename.replace(base_dir, '').lstrip('/'),
                 'source': ''.join(source).rstrip(),
                 'coverage': coverage_list,
             })

--- a/coveralls/tests.py
+++ b/coveralls/tests.py
@@ -103,6 +103,9 @@ class CoverallsTestCase(TestCase):
 
     def test_gitrepo_branch(self):
         git = repository.gitrepo(Arguments.base_dir)
+        print(git)
+        print(GIT_EXP)
+        raise
         self.assertTrue(git['branch'] in (GIT_EXP['branch'], 'HEAD'))
 
     def test_coveralls(self):

--- a/coveralls/tests.py
+++ b/coveralls/tests.py
@@ -2,6 +2,7 @@
 import json
 from unittest import TestCase
 from coverage.plugin import FileReporter
+from coverage.python import PythonFileReporter
 from coverage.misc import NotPython
 from coveralls.control import coveralls
 from coveralls.report import CoverallsReporter
@@ -168,7 +169,7 @@ class NotAPythonTestCase(TestCase):
         coverage.load()
         self.reporter = CoverallsReporter(coverage, coverage.config)
         self.reporter.find_file_reporters(None)
-        self.reporter.file_reporters.append(FileReporter('LICENSE'))
+        self.reporter.file_reporters.append(PythonFileReporter('LICENSE', coverage=coverage))
 
     def test_report_raises(self):
         self.assertRaises(NotPython, self.reporter.report, Arguments.base_dir)

--- a/coveralls/tests.py
+++ b/coveralls/tests.py
@@ -103,9 +103,6 @@ class CoverallsTestCase(TestCase):
 
     def test_gitrepo_branch(self):
         git = repository.gitrepo(Arguments.base_dir)
-        print(git)
-        print(GIT_EXP)
-        raise
         self.assertTrue(git['branch'] in (GIT_EXP['branch'], 'HEAD'))
 
     def test_coveralls(self):

--- a/coveralls/tests.py
+++ b/coveralls/tests.py
@@ -1,8 +1,7 @@
 # coding=utf-8
 import json
 from unittest import TestCase
-from coverage.codeunit import CodeUnit
-from coverage.files import FileLocator
+from coverage.plugin import FileReporter
 from coverage.misc import NotPython
 from coveralls.control import coveralls
 from coveralls.report import CoverallsReporter
@@ -153,8 +152,8 @@ class NotAFileTestCase(TestCase):
         coverage = coveralls(data_file=Arguments.data_file, config_file=Arguments.config_file)
         coverage.load()
         self.reporter = CoverallsReporter(coverage, coverage.config)
-        self.reporter.find_code_units(None)
-        self.reporter.code_units.append(CodeUnit('NotAFile.py', FileLocator()))
+        self.reporter.find_file_reporters(None)
+        self.reporter.file_reporters.append(FileReporter('NotAFile.py'))
 
     def test_report_raises(self):
         self.assertRaises(IOError, self.reporter.report, Arguments.base_dir)
@@ -168,8 +167,8 @@ class NotAPythonTestCase(TestCase):
         coverage = coveralls(data_file=Arguments.data_file, config_file=Arguments.config_file)
         coverage.load()
         self.reporter = CoverallsReporter(coverage, coverage.config)
-        self.reporter.find_code_units(None)
-        self.reporter.code_units.append(CodeUnit('LICENSE', FileLocator()))
+        self.reporter.find_file_reporters(None)
+        self.reporter.file_reporters.append(FileReporter('LICENSE'))
 
     def test_report_raises(self):
         self.assertRaises(NotPython, self.reporter.report, Arguments.base_dir)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 PyYAML
 requests
-coverage==3.7.1
+coverage==4.0.3
 six
 sh


### PR DESCRIPTION
Main work is done by [rdegges](https://github.com/z4r/python-coveralls/pull/41).

Test failure will be fixed when merged, it is caused by this line in `coveralls/repository.py`:

    branch = os.environ.get('CIRCLE_BRANCH') or os.environ.get('TRAVIS_BRANCH', sh.git('rev-parse', '--abbrev-ref', 'HEAD').strip())

`TRAVIS_BRANCH` overwrites result from git command. Not sure what to do with it.