### PR TITLE
Include the license file

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,1 @@
-include README.* *.txt
+include LICENSE README.* *.txt


### PR DESCRIPTION
Add the license file to `MANIFEST.in` to ensure it is included in packages (e.g. `sdist`s).