### PR TITLE
Add Windows support

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,33 @@
+environment:
+  matrix:
+  - PYTHON: C:\Python27\python.exe
+    platform: Any CPU
+  - PYTHON: C:\Python33\python.exe
+    platform: Any CPU
+  - PYTHON: C:\Python34\python.exe
+    platform: Any CPU
+  - PYTHON: C:\Python35\python.exe
+    platform: Any CPU
+
+before_build:
+  - "%PYTHON% -m pip install virtualenv"
+  - "%PYTHON% -m virtualenv venv"
+  - venv\Scripts\activate.bat
+
+build_script:
+  - pip install -U pip
+  - python setup.py develop
+
+before_test:
+  - pip install -r test_requirements.txt
+  - 'git clone https://github.com/z4r/python-coveralls-example.git'
+  - cd python-coveralls-example
+  - git checkout -qf 3e82fd5159b84bebe9bc6c9fd3959f322e6f7098
+  - py.test example/tests.py --cov=example
+  - cd %APPVEYOR_BUILD_FOLDER%
+
+test_script:
+  - py.test coveralls/tests.py --doctest-modules --pep8 coveralls -v --cov coveralls --cov-report term-missing
+
+#on_success:
+#  - coveralls

--- a/coveralls/report.py
+++ b/coveralls/report.py
@@ -1,3 +1,6 @@
+
+import os
+
 import json
 
 from coverage.report import Reporter
@@ -28,7 +31,7 @@ class CoverallsReporter(Reporter):
                 if lineno + 1 in analysis.statements:
                     coverage_list[lineno] = int(lineno + 1 not in analysis.missing)
             ret.append({
-                'name': fr.filename.replace(base_dir, '').lstrip('/'),
+                'name': fr.filename.replace(base_dir, '').lstrip(os.sep).replace(os.sep, '/'),
                 'source': ''.join(source).rstrip(),
                 'coverage': coverage_list,
             })

--- a/coveralls/repository.py
+++ b/coveralls/repository.py
@@ -1,15 +1,23 @@
+
+import sys
 import os
-import sh
+
+try:
+    from subprocess32 import check_output
+except ImportError:
+    from subprocess import check_output
+
 FORMAT = '%n'.join(['%H', '%aN', '%ae', '%cN', '%ce', '%s'])
 
 
 def gitrepo(root):
-    tmpdir = sh.pwd().strip()
-    sh.cd(root)
-    gitlog = sh.git('--no-pager', 'log', '-1', pretty="format:%s" % FORMAT).split('\n', 5)
-    branch = os.environ.get('CIRCLE_BRANCH') or os.environ.get('TRAVIS_BRANCH', sh.git('rev-parse', '--abbrev-ref', 'HEAD').strip())
-    remotes = [x.split() for x in filter(lambda x: x.endswith('(fetch)'), sh.git.remote('-v').strip().splitlines())]
-    sh.cd(tmpdir)
+    tmpdir = os.getcwd()
+    os.chdir(root)
+    gitlog = check_output(['git', '--no-pager', 'log', '-1', '--pretty=format:%s' % FORMAT], universal_newlines=True).split('\n', 5)
+    branch = (os.environ.get('CIRCLE_BRANCH') or
+              os.environ.get('TRAVIS_BRANCH', check_output(['git', 'rev-parse', '--abbrev-ref', 'HEAD']).strip()))
+    remotes = [x.split() for x in filter(lambda x: x.endswith('(fetch)'), check_output(['git', 'remote', '-v']).decode().strip().splitlines())]
+    os.chdir(tmpdir)
     return {
         "head": {
             "id": gitlog[0],

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,0 @@
-PyYAML
-requests
-coverage==4.0.3
-six
-sh

--- a/setup.py
+++ b/setup.py
@@ -19,9 +19,16 @@ readme = open(os.path.join(wd, 'README.rst'), 'r').readlines()
 description = readme[1]
 long_description = ''.join(readme)
 
-reqs = open(os.path.join(os.path.dirname(__file__), 'requirements.txt')).readlines()
+reqs = [
+        'PyYAML',
+        'requests',
+        'coverage==4.0.3',
+        'six',
+        ]
+
 if sys.version_info < (2, 7):
     reqs.append('argparse')
+    reqs.append('subprocess32')
 
 setup(
     name=name,


### PR DESCRIPTION
I've included an AppVeyor script to run tests on, it mostly matches the Travis test environment.  All tests pass on Python 2.7, which is good enough to deploy coverage data made by any other version.

coverage-4.0.3 doesn't seem to want to install on any later versions of Python on Windows.

test_gitrepo_branch seemed to be failing on Travis before I started working on this pull request.  The test passes on AppVeyor.

The pbs module wasn't working as a fallback for sh, so I had to replace sh with subprocess.check_output, which works similarly enough.  Keep in mind it will return bytes on Python 3.  Hopefully this is acceptable.

Since python-coveralls can't be run as a module you'll need to make a small virtual environment for it to run on AppVeyor.  Assuming the COVERALLS_REPO_TOKEN is set, the script goes something like this:
```
on_success:
- "C:\\Python27\\python.exe -m virtualenv py27venv"
- py27venv\Scripts\activate.bat
- pip install python-coveralls
# or install from my topic branch directly
#- "pip install git+https://github.com/HexDecimal/python-coveralls.git@windows-support"
- coveralls
```

This will resolve issue #26 