### PR TITLE
Removed version constraint for the 'coverage' package

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ long_description = ''.join(readme)
 reqs = [
         'PyYAML',
         'requests',
-        'coverage==4.0.3',
+        'coverage',
         'six',
         ]
 

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ long_description = ''.join(readme)
 reqs = [
         'PyYAML',
         'requests',
-        'coverage',
+        'coverage>=4.4',
         'six',
         ]
 


### PR DESCRIPTION
The required version of coverage doesn't fit for the needed version of pytest-cov